### PR TITLE
docs(config): add theme to config

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,6 @@
+title: PawFinder API Documentation
+description: Connecting Paws with People
+show_downloads: false
+remote_theme: pages-themes/cayman@v0.2.0
+plugins:
+- jekyll-remote-theme


### PR DESCRIPTION
- resolves [issue #21](https://github.com/rhyannonjoy/pawfinder-service/issues/21)
- squashed 4 commits
- create _config.yml to add theme
- initially used tactile, but found the red text unreadable, replaced with cayman theme