### PR TITLE
docs(api-references): edit code samples from shell to bash

### DIFF
--- a/docs/api-references/api-reference.md
+++ b/docs/api-references/api-reference.md
@@ -4,7 +4,7 @@
 - All requests and responses are in the JSON data format.
 - Recommended base URL:
 
-```shell
+```bash
 http://localhost:3000
 ```
 

--- a/docs/api-references/delete-pets-by-id.md
+++ b/docs/api-references/delete-pets-by-id.md
@@ -4,7 +4,7 @@ This operation removes a pet record from the PawFinder database.
 
 ## Endpoint structure
 
-```shell
+```bash
 DELETE /pets/{id}
 ```
 
@@ -26,7 +26,7 @@ This operation doesn't require a request body.
 
 ## cURL request
 
-```shell
+```bash
 curl -X DELETE http://localhost:3000/pets/6 \
   -H "Authorization: Bearer pawfinder-secret-2025"
 ```

--- a/docs/api-references/delete-shelters-by-id.md
+++ b/docs/api-references/delete-shelters-by-id.md
@@ -4,7 +4,7 @@ This operation removes a shelter record from the PawFinder database.
 
 ## Endpoint structure
 
-```shell
+```bash
 DELETE /shelters/{id}
 ```
 
@@ -26,7 +26,7 @@ This operation doesn't require a request body.
 
 ## cURL request
 
-```shell
+```bash
 curl -X DELETE http://localhost:3000/shelters/5 \
   -H "Authorization: Bearer pawfinder-secret-2025"
 ```

--- a/docs/api-references/get-all-pets.md
+++ b/docs/api-references/get-all-pets.md
@@ -4,7 +4,7 @@ This operation retrieves all pets in the PawFinder system.
 
 ## Endpoint structure
 
-```shell
+```bash
 GET /pets
 ```
 
@@ -24,7 +24,7 @@ This operation doesn't require a request body.
 
 ## cURL request
 
-```shell
+```bash
 curl -X GET http://localhost:3000/pets
 ```
 

--- a/docs/api-references/get-all-shelters.md
+++ b/docs/api-references/get-all-shelters.md
@@ -4,7 +4,7 @@ This operation retrieves all shelter profiles in the PawFinder system.
 
 ## Endpoint structure
 
-```shell
+```bash
 GET /shelters
 ```
 
@@ -24,7 +24,7 @@ This operation doesn't require a request body.
 
 ## cURL request
 
-```shell
+```bash
 curl -X GET http://localhost:3000/shelters
 ```
 

--- a/docs/api-references/get-pets-by-id.md
+++ b/docs/api-references/get-pets-by-id.md
@@ -4,7 +4,7 @@ This operation retrieves a pet's profile by their ID.
 
 ## Endpoint structure
 
-```shell
+```bash
 GET /pets/{id}
 ```
 
@@ -26,7 +26,7 @@ This operation doesn't require a request body.
 
 ## cURL request
 
-```shell
+```bash
 curl -X GET http://localhost:3000/pets/1
 ```
 

--- a/docs/api-references/get-pets-from-shelter.md
+++ b/docs/api-references/get-pets-from-shelter.md
@@ -4,7 +4,7 @@ This operation retrieves all pets associated with a specific shelter.
 
 ## Endpoint structure
 
-```shell
+```bash
 GET /shelters/{id}/pets
 ```
 
@@ -30,7 +30,7 @@ This operation doesn't require a request body.
 
 ## cURL request
 
-```shell
+```bash
 curl -X GET http://localhost:3000/shelters/1/pets
 ```
 

--- a/docs/api-references/get-pets-with-filters.md
+++ b/docs/api-references/get-pets-with-filters.md
@@ -4,7 +4,7 @@ This operation retrieves pets profiles that match the specified filter criteria.
 
 ## Endpoint structure
 
-```shell
+```bash
 GET /pets?{query_parameters}
 ```
 
@@ -38,7 +38,7 @@ This operation doesn't require a request body.
 
 ## cURL request
 
-```shell
+```bash
 curl -X GET http://localhost:3000/pets?species=cat&status=available
 ```
 

--- a/docs/api-references/get-shelters-by-id.md
+++ b/docs/api-references/get-shelters-by-id.md
@@ -4,7 +4,7 @@ This operation retrieves a shelter's profile by their ID.
 
 ## Endpoint structure
 
-```shell
+```bash
 GET /shelter/{id}
 ```
 
@@ -26,7 +26,7 @@ This operation doesn't require a request body.
 
 ## cURL request
 
-```shell
+```bash
 curl -X GET http://localhost:3000/shelters/1
 ```
 

--- a/docs/api-references/patch-pets-by-id.md
+++ b/docs/api-references/patch-pets-by-id.md
@@ -11,7 +11,7 @@ request, fields not present in the request remain unchanged.
 
 ## Endpoint structure
 
-```shell
+```bash
 PATCH /pets/{id}
 ```
 
@@ -57,7 +57,7 @@ All fields required.
 
 ## cURL request
 
-```shell
+```bash
 curl -X PATCH http://localhost:3000/pets/4 \
   -H "Authorization: Bearer pawfinder-secret-2025" \
   -H "Content-Type: application/json" \

--- a/docs/api-references/patch-shelters-by-id.md
+++ b/docs/api-references/patch-shelters-by-id.md
@@ -12,7 +12,7 @@ request, fields not present in the request remain unchanged.
 
 ## Endpoint structure
 
-```shell
+```bash
 PATCH /shelters/{id}
 ```
 
@@ -49,7 +49,7 @@ ignores `id` fields in `PATCH` request bodies or returns a `400` error.
 
 ## cURL request
 
-```shell
+```bash
 curl -X PATCH http://localhost:3000/shelters/1 \
   -H "Authorization: Bearer pawfinder-secret-2025" \
   -H "Content-Type: application/json" \

--- a/docs/api-references/post-pets.md
+++ b/docs/api-references/post-pets.md
@@ -4,7 +4,7 @@ This operation creates a new pet profile in the PawFinder system.
 
 ## Endpoint structure
 
-```shell
+```bash
 POST /pets
 ```
 
@@ -54,7 +54,7 @@ PawFinder auto-generates pet unique identifiers, `id`. The system ignores
 
 ## cURL request
 
-```shell
+```bash
 curl -X POST http://localhost:3000/pets \
   -H "Authorization: Bearer pawfinder-secret-2025" \
   -H "Content-Type: application/json" \

--- a/docs/api-references/post-shelters.md
+++ b/docs/api-references/post-shelters.md
@@ -4,7 +4,7 @@ This operation creates a new shelter profile in the PawFinder system.
 
 ## Endpoint structure
 
-```shell
+```bash
 POST /shelters
 ```
 
@@ -41,7 +41,7 @@ ignores `id` fields in `POST` request bodies or returns a `400` error.
 
 ## cURL request
 
-```shell
+```bash
 curl -X POST http://localhost:3000/shelters \
   -H "Authorization: Bearer pawfinder-secret-2025" \
   -H "Content-Type: application/json" \

--- a/docs/api-references/put-pets-by-id.md
+++ b/docs/api-references/put-pets-by-id.md
@@ -11,7 +11,7 @@ request, fields not present in the request remain unchanged.
 
 ## Endpoint structure
 
-```shell
+```bash
 PUT /pets/{id}
 ```
 
@@ -61,7 +61,7 @@ ignores `id` fields in `PUT` request bodies or returns a `400` error.
 
 ## cURL request
 
-```shell
+```bash
 curl -X PUT http://localhost:3000/pets/4 \
   -H "Authorization: Bearer pawfinder-secret-2025" \
   -H "Content-Type: application/json" \

--- a/docs/api-references/put-shelters-by-id.md
+++ b/docs/api-references/put-shelters-by-id.md
@@ -11,7 +11,7 @@ request, fields not present in the request remain unchanged.
 
 ## Endpoint structure
 
-```shell
+```bash
 PUT /shelters/{id}
 ```
 
@@ -48,7 +48,7 @@ ignores `id` fields in `PUT` request bodies or returns a `400` error.
 
 ## cURL request
 
-```shell
+```bash
 curl -X PUT http://localhost:3000/shelters/1 \
   -H "Authorization: Bearer pawfinder-secret-2025" \
   -H "Content-Type: application/json" \

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,8 +43,8 @@ Tour task-based guides for common workflows and use cases.
 
 ## API Reference
 
-Survey [the complete technical](./api-references/api-reference.md) reference for
-all endpoint operations, parameters, and responses.
+Survey [the complete technical](./api-references/api-reference.md) reference
+for all endpoint operations, parameters, and responses.
 
 ### `/pets`
 

--- a/docs/overview/tutorial-requirements.md
+++ b/docs/overview/tutorial-requirements.md
@@ -11,7 +11,8 @@ separate browser tabs before installing any software.
 <!-- vale Google.Acronyms = NO -->
 
 - A [GitHub account](https://github.com)
-- A development system running a current version or a long-term support, also known as _LTS_, version of the Windows, MacOS, or Linux operating system.
+- A development system running a current version or a long-term support,
+also known as _LTS_, version of the Windows, MacOS, or Linux operating system.
 - The following software:
     - [Git, command line](https://docs.github.com/en/get-started/quickstart/set-up-git)
     - [GitHub Desktop](https://desktop.github.com) _optional, but recommended_
@@ -33,9 +34,11 @@ separate browser tabs before installing any software.
 
 ## Verify the development setup
 
-1. Create and checkout a test branch of the fork of the PawFinder Service repository. `GitHub repository workspace` is the directory that contains the fork of the `pawfinder-service` repository.
+1. Create and checkout a test branch of the fork of the PawFinder Service repository.
+`GitHub repository workspace` is the directory that contains the fork of
+the `pawfinder-service` repository.
 
-    ```shell
+    ```bash
     cd <GitHub repository workspace>
     ls
     # (see the pawfinder-service directory in the list)
@@ -50,7 +53,7 @@ separate browser tabs before installing any software.
 
 2. Make a test call to the service:
 
-    ```shell
+    ```bash
     curl http://localhost:3000/pets
     ```
 
@@ -100,7 +103,7 @@ separate browser tabs before installing any software.
     ```
 
 When encountering errors in any procedure steps, investigate,
-and correct the error before proceeding. Common situations
+and correct the error before moving forward. Common situations
 that cause errors:
 
 - Mistyped commands


### PR DESCRIPTION
- Resolves [issue #29](https://github.com/rhyannonjoy/pawfinder-service/issues/29)
- These changes have no impact on the rendered documentation in GitHub Pages
- These changes have no impact on the repository rendering in GitHub
- These changes only impact local development, as the language specifications show up in Markdown / VSCode Markdown Preview
- Claude prompt: "Are cURL commands not shell, but bash?"
- Claude answer: "shell and bash are related but not the same” - 

> Shell — A general term for command-line interpreters. Bash is one type of shell.
> Bash — A specific shell (Bourne Again Shell), the most common default on Linux and macOS.
> 
> cURL commands work in any shell — bash, zsh, sh, fish, etc. They're not specific to one. The syntax I've been showing you is standard and will work in bash, zsh, or most other shells.
> The difference you might notice:
> 
> Bash uses $() for command substitution
> Fish uses different syntax
> Some shells handle escaping or quotes slightly differently
> 
> But basic cURL commands like curl -X GET "http://localhost:3000/pets" work identically across all common shells.
